### PR TITLE
Fix missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ cryptography
 dask
 decorator
 fastapi
+fastmcp
 filelock
 flask
 google-auth


### PR DESCRIPTION
## Summary
- include fastmcp in requirements

## Testing
- `pip index versions fastmcp` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f8159a0dc8320a3b314c280501986