### PR TITLE
Add FastMCP to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -77,3 +77,4 @@ watchdog
 websockets
 wheel
 yarl
+fastmcp


### PR DESCRIPTION
## Summary
- add missing `fastmcp` package to `requirements.txt`

## Testing
- `nl -ba requirements.txt | tail -n 6`

------
https://chatgpt.com/codex/tasks/task_e_683f829118e083208706206a7ffaf373