### PR TITLE
Add business tools module with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ pip install -r requirements.txt
 jupyter notebook
 ```
 
+### 5️⃣ **Run Tests**
+```bash
+pytest
+```
+
 ---
 ## 🔑 Key Features
 

--- a/business_tools.py
+++ b/business_tools.py
@@ -1,0 +1,18 @@
+"""Utility functions for business operations."""
+
+import csv
+
+
+def calculate_profit(revenue: float, cost: float) -> float:
+    """Return the profit calculated as revenue minus cost."""
+    return revenue - cost
+
+
+def get_sales_from_csv(filename: str) -> float:
+    """Read a CSV of sales data and return total sales as float."""
+    total = 0.0
+    with open(filename, newline="") as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            total += float(row["sales"])
+    return total

--- a/tests/test_business_tools.py
+++ b/tests/test_business_tools.py
@@ -1,0 +1,17 @@
+import os
+import pytest
+
+from business_tools import calculate_profit, get_sales_from_csv
+
+
+def test_calculate_profit():
+    assert calculate_profit(1000, 600) == 400
+
+
+def test_get_sales_from_csv(tmp_path):
+    # copy sample sales_data.csv to a temp directory to avoid modifying repo file
+    src = os.path.join(os.path.dirname(__file__), os.pardir, 'sales_data.csv')
+    dst = tmp_path / 'sales_data.csv'
+    with open(src, 'r') as fsrc, open(dst, 'w') as fdst:
+        fdst.write(fsrc.read())
+    assert get_sales_from_csv(str(dst)) == 950


### PR DESCRIPTION
## Summary
- create `business_tools` module for utility functions
- add pytest tests for business tools
- document how to run tests in `README`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f82f972448320a8bdbf70a126ae42