### PR TITLE
Ensure pytest imports repo modules

### DIFF
--- a/tests/test_business_tools.py
+++ b/tests/test_business_tools.py
@@ -1,5 +1,10 @@
+
 import os
+import sys
 import pytest
+
+# Ensure the repository root is on sys.path so business_tools can be imported
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)))
 
 from business_tools import calculate_profit, get_sales_from_csv
 


### PR DESCRIPTION
## Summary
- add repo root to `sys.path` in tests

## Testing
- `pytest -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f89f19a148320aea13c7ac0a1d4bd