### PR TITLE
Ignore pytest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ __pycache__/
 *.pyo
 *.pyd
 
+# Ignore pytest cache
+.pytest_cache/
+
 # Ignore system files
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary
- prevent committing pytest cache files by ignoring `.pytest_cache/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f8cbe0c8483209ab082b73d94fe8e