### PR TITLE
Add premium utilities and notebook demo

### DIFF
--- a/notebooks/Model-Context-Protocol-101.ipynb
+++ b/notebooks/Model-Context-Protocol-101.ipynb
@@ -7,7 +7,13 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "import pandas as pd"
+        "import pandas as pd\n",
+        "from business_tools import (\n",
+        "    calculate_commission,\n",
+        "    calculate_total_premium,\n",
+        "    filter_policies_by_state,\n",
+        "    load_insurance_sales,\n",
+        ")\n"
       ]
     },
     {
@@ -108,7 +114,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "import pandas as pd\n",
         "\n",
         "@mcp.tool()\n",
         "def get_sales_from_csv(file_path: str) -> float:\n",
@@ -199,6 +204,55 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {},
+      "id": "step-7-load",
+      "source": [
+        "## Step 7: Load `insurance_sales.csv`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "id": "step-7-code",
+      "source": [
+        "records = load_insurance_sales('data/insurance_sales.csv')\n",
+        "print(f'Total records: {len(records)}')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "id": "step-8-code",
+      "source": [
+        "total_premium = calculate_total_premium(records)\n",
+        "print('Total Premium:', total_premium)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "id": "step-9-code",
+      "source": [
+        "ca_policies = filter_policies_by_state(records, 'CA')\n",
+        "print('CA Policies:', len(ca_policies))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "id": "step-9-explain",
+      "source": [
+        "These steps show how quickly you can tally premiums and isolate policies by state\u2014handy for reviewing territory performance and carrier payouts."
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "id": "3aee3fb6-e2ea-4761-b4e1-41d13ef8c507",
       "metadata": {},
       "source": [
@@ -244,14 +298,6 @@
         "\n",
         "\ud83d\ude80\ud83d\udd25 Let\u2019s build something amazing!"
       ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "74bb86ba-7c3a-4ddf-b7a2-97efb8e29763",
-      "metadata": {},
-      "outputs": [],
-      "source": []
     }
   ],
   "metadata": {

--- a/src/business_tools.py
+++ b/src/business_tools.py
@@ -63,3 +63,22 @@ def filter_by_state(records: list[dict[str, str]], state: str) -> list[dict[str,
         Filtered list containing rows where ``State`` equals ``state``.
     """
     return [row for row in records if row["State"] == state]
+
+def calculate_total_premium(records: list[dict[str, str]]) -> float:
+    """Return the sum of the ``Premium`` column from insurance records.
+
+    Args:
+        records: Rows loaded via :func:`load_insurance_sales`.
+
+    Returns:
+        Total premium as a float.
+    """
+    total = 0.0
+    for row in records:
+        total += float(row["Premium"])
+    return total
+
+
+def filter_policies_by_state(records: list[dict[str, str]], state: str) -> list[dict[str, str]]:
+    """Wrapper around :func:`filter_by_state` with a clearer name."""
+    return filter_by_state(records, state)

--- a/tests/test_business_tools.py
+++ b/tests/test_business_tools.py
@@ -13,6 +13,8 @@ from business_tools import (  # noqa: E402
     load_insurance_sales,
     total_commission,
     filter_by_state,
+    calculate_total_premium,
+    filter_policies_by_state,
 )
 
 
@@ -51,4 +53,22 @@ def test_filter_by_state(tmp_path):
         fdst.write(fsrc.read())
     records = load_insurance_sales(str(dst))
     ca_records = filter_by_state(records, "CA")
+    assert len(ca_records) == 4
+
+def test_calculate_total_premium(tmp_path):
+    src = os.path.join(REPO_ROOT, "data", "insurance_sales.csv")
+    dst = tmp_path / "insurance_sales.csv"
+    with open(src, "r") as fsrc, open(dst, "w") as fdst:
+        fdst.write(fsrc.read())
+    records = load_insurance_sales(str(dst))
+    assert calculate_total_premium(records) == 18480.0
+
+
+def test_filter_policies_by_state(tmp_path):
+    src = os.path.join(REPO_ROOT, "data", "insurance_sales.csv")
+    dst = tmp_path / "insurance_sales.csv"
+    with open(src, "r") as fsrc, open(dst, "w") as fdst:
+        fdst.write(fsrc.read())
+    records = load_insurance_sales(str(dst))
+    ca_records = filter_policies_by_state(records, "CA")
     assert len(ca_records) == 4


### PR DESCRIPTION
## Summary
- add `calculate_total_premium` and `filter_policies_by_state`
- show premium calculations in the example notebook
- test the new helper functions

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68423251ccc88320992097888f70e365