### PR TITLE
Add CLI with argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,18 @@ This tutorial walks through how to:
 ✅ **Test MCP tools locally**  
 ✅ **Expand MCP with custom functions**  
 ✅ **Read and process CSV files**  
-✅ **Deploy and use MCP tools efficiently**  
+✅ **Deploy and use MCP tools efficiently**
+
+## 🔄 Workflow
+Use the command-line interface to run common tasks directly from the terminal.
+
+```bash
+# Calculate profit from revenue and cost
+python src/cli.py profit 1000 600
+
+# Total commission from the sample dataset
+python src/cli.py commission data/insurance_sales.csv
+```
 
 ---
 ## 📂 Project Structure

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,64 @@
+"""Command line interface for business tools.
+
+Provides a small set of utilities to perform
+common calculations from the terminal.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from business_tools import (
+    calculate_profit,
+    calculate_total_premium,
+    load_insurance_sales,
+    total_commission,
+)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the command line interface.
+
+    Args:
+        argv: Optional list of arguments for easier testing.
+    """
+    parser = argparse.ArgumentParser(
+        description="Business tools command line interface",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    profit_parser = subparsers.add_parser(
+        "profit", help="Calculate profit from revenue and cost"
+    )
+    profit_parser.add_argument("revenue", type=float, help="Revenue in USD")
+    profit_parser.add_argument("cost", type=float, help="Cost in USD")
+
+    commission_parser = subparsers.add_parser(
+        "commission",
+        help="Calculate total commission from an insurance sales CSV",
+    )
+    commission_parser.add_argument(
+        "file", type=Path, help="Path to insurance_sales.csv"
+    )
+
+    premium_parser = subparsers.add_parser(
+        "premium", help="Calculate total premium from an insurance sales CSV"
+    )
+    premium_parser.add_argument("file", type=Path, help="Path to insurance_sales.csv")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "profit":
+        result = calculate_profit(args.revenue, args.cost)
+        print(int(result) if result.is_integer() else result)
+    elif args.command == "commission":
+        records = load_insurance_sales(str(args.file))
+        print(total_commission(records))
+    elif args.command == "premium":
+        records = load_insurance_sales(str(args.file))
+        print(calculate_total_premium(records))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,33 @@
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI = REPO_ROOT / "src" / "cli.py"
+
+
+def run_cli(args: list[str]) -> str:
+    """Run the CLI with the given arguments and return stdout."""
+    cmd = [sys.executable, str(CLI), *args]
+    result = subprocess.check_output(cmd, text=True)
+    return result.strip()
+
+
+def test_profit_cli():
+    assert run_cli(["profit", "100", "40"]) == "60"
+
+
+def test_commission_cli(tmp_path: Path):
+    src = REPO_ROOT / "data" / "insurance_sales.csv"
+    dst = tmp_path / "insurance_sales.csv"
+    dst.write_text(src.read_text())
+    out = run_cli(["commission", str(dst)])
+    assert out == "2545.0"
+
+
+def test_premium_cli(tmp_path: Path):
+    src = REPO_ROOT / "data" / "insurance_sales.csv"
+    dst = tmp_path / "insurance_sales.csv"
+    dst.write_text(src.read_text())
+    out = run_cli(["premium", str(dst)])
+    assert out == "18480.0"


### PR DESCRIPTION
## Summary
- build `src/cli.py` for running business tools from the command line
- add tests covering CLI commands
- document CLI usage in the new Workflow section of the README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842362d58fc83208fbfdc6bae456447