### PR TITLE
chore: align Python version and add lint checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with ruff
+      run: |
+        ruff .
+    - name: Type check with mypy
+      run: |
+        mypy --strict .
     - name: Run tests
       run: |
         if [ -d tests ]; then pytest -q; else echo "No tests"; fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🚀 Model-Context-Protocol-101
 
-[![Python](https://img.shields.io/badge/Python-3.8%2B-blue.svg)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/Python-3.10%2B-blue.svg)](https://www.python.org/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/itprodirect/Model-Context-Protocol-101/ci.yml)](https://github.com/itprodirect/Model-Context-Protocol-101/actions)
 [![Dependencies](https://img.shields.io/badge/Dependencies-Updated-brightgreen.svg)](https://github.com/itprodirect/Model-Context-Protocol-101/blob/main/requirements.txt)
@@ -159,7 +159,7 @@ For questions or collaborations, connect with me on **LinkedIn** or open an **Is
 **Virtual environment won't activate**
 Make sure you run `python -m venv venv` and then activate it with
 `source venv/bin/activate` on Mac/Linux or `venv\Scripts\activate` on Windows.
-Verify Python 3.8+ is installed.
+Verify Python 3.10+ is installed.
 
 **Missing packages**
 Run `pip install -r requirements.txt` from the project root while your virtual

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-fastmcp
-pandas
-jupyter
-pytest
+fastmcp==2.12.2
+pandas==2.3.2
+jupyter==1.1.1
+pytest==8.4.1
+ruff==0.12.11
+mypy==1.17.1


### PR DESCRIPTION
## Summary
- document Python 3.10+ requirement in README
- pin dependency versions and include ruff/mypy
- run ruff and mypy in CI

## Testing
- `pip install -r requirements.txt`
- `ruff check .`
- `mypy --strict .`
- `pytest -q`

## Agents
- DEV-AGENT
- QA-AGENT

------
https://chatgpt.com/codex/tasks/task_e_68bf58ae11a88320b6d18ca0b99ce139