### PR TITLE
fix: use current ruff check command in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with ruff
       run: |
-        ruff .
+        ruff check .
     - name: Type check with mypy
       run: |
         mypy --strict .


### PR DESCRIPTION
## Summary
- update the CI Ruff invocation from `ruff .` to `ruff check .`
- keep the baseline fix scoped to the existing workflow command only

## Validation
- `ruff .` fails locally with `error: unrecognized subcommand '.'` using the repo-pinned Ruff
- `ruff check .`
- `mypy --strict .`
- `pytest -q`