### PR TITLE
fix: restore legacy import shims

### DIFF
--- a/src/business_tools.py
+++ b/src/business_tools.py
@@ -1,0 +1,25 @@
+"""Compatibility wrapper for legacy ``business_tools`` imports."""
+
+from __future__ import annotations
+
+from mcp101 import business_tools as _impl
+
+calculate_profit = _impl.calculate_profit
+get_sales_from_csv = _impl.get_sales_from_csv
+calculate_commission = _impl.calculate_commission
+load_insurance_sales = _impl.load_insurance_sales
+total_commission = _impl.total_commission
+filter_by_state = _impl.filter_by_state
+calculate_total_premium = _impl.calculate_total_premium
+filter_policies_by_state = _impl.filter_policies_by_state
+
+__all__ = [
+    "calculate_profit",
+    "get_sales_from_csv",
+    "calculate_commission",
+    "load_insurance_sales",
+    "total_commission",
+    "filter_by_state",
+    "calculate_total_premium",
+    "filter_policies_by_state",
+]

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,11 @@
+"""Compatibility wrapper for the legacy ``cli`` module."""
+
+from __future__ import annotations
+
+from mcp101.cli import main as main
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_business_tools.py
+++ b/tests/test_business_tools.py
@@ -1,4 +1,5 @@
 
+import importlib
 import sys
 from pathlib import Path
 
@@ -54,3 +55,20 @@ def test_filter_policies_by_state(insurance_sales_csv: Path) -> None:
     records = load_insurance_sales(str(insurance_sales_csv))
     ca_records = filter_policies_by_state(records, "CA")
     assert len(ca_records) == 4
+
+
+def test_legacy_business_tools_reexports() -> None:
+    legacy = importlib.import_module("business_tools")
+    modern = importlib.import_module("mcp101.business_tools")
+
+    for name in [
+        "calculate_profit",
+        "get_sales_from_csv",
+        "calculate_commission",
+        "load_insurance_sales",
+        "total_commission",
+        "filter_by_state",
+        "calculate_total_premium",
+        "filter_policies_by_state",
+    ]:
+        assert getattr(legacy, name) is getattr(modern, name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,12 +3,14 @@ import subprocess
 import sys
 from pathlib import Path
 
-MODULE = "mcp101.cli"
+import pytest
+
+MODULES = ("mcp101.cli", "cli")
 
 
-def run_cli(args: list[str]) -> str:
-    """Run the CLI with the given arguments and return stdout."""
-    cmd = [sys.executable, "-m", MODULE, *args]
+def run_cli(module: str, args: list[str]) -> str:
+    """Run the CLI module with the given arguments and return stdout."""
+    cmd = [sys.executable, "-m", module, *args]
     env = os.environ.copy()
     src_dir = Path(__file__).resolve().parents[1] / "src"
     env["PYTHONPATH"] = os.pathsep.join(
@@ -18,15 +20,18 @@ def run_cli(args: list[str]) -> str:
     return result.strip()
 
 
-def test_profit_cli() -> None:
-    assert run_cli(["profit", "100", "40"]) == "60"
+@pytest.mark.parametrize("module", MODULES)
+def test_profit_cli(module: str) -> None:
+    assert run_cli(module, ["profit", "100", "40"]) == "60"
 
 
-def test_commission_cli(insurance_sales_csv: Path) -> None:
-    out = run_cli(["commission", str(insurance_sales_csv)])
+@pytest.mark.parametrize("module", MODULES)
+def test_commission_cli(module: str, insurance_sales_csv: Path) -> None:
+    out = run_cli(module, ["commission", str(insurance_sales_csv)])
     assert out == "2545.0"
 
 
-def test_premium_cli(insurance_sales_csv: Path) -> None:
-    out = run_cli(["premium", str(insurance_sales_csv)])
+@pytest.mark.parametrize("module", MODULES)
+def test_premium_cli(module: str, insurance_sales_csv: Path) -> None:
+    out = run_cli(module, ["premium", str(insurance_sales_csv)])
     assert out == "18480.0"


### PR DESCRIPTION
## Summary
- add legacy src/business_tools.py and src/cli.py wrappers that delegate to the mcp101 package
- extend tests so old imports and python -m cli remain covered alongside the package entry point
- preserves the useful compatibility idea from #25 without notebook, requirements, or packaging churn

## Testing
- python -m pytest -q
- python -m ruff check .
- python -m mypy --strict .

Refs #25